### PR TITLE
Remove tracable directive on non-Tracable parse_players

### DIFF
--- a/src/data/chunks/data_data_chunk.rs
+++ b/src/data/chunks/data_data_chunk.rs
@@ -90,7 +90,6 @@ impl DataDataChunk {
         le_u32(input)
     }
 
-    #[tracable_parser]
     fn parse_players(version: u16) -> impl FnMut(Span) -> ParserResult<Vec<Player>> {
         move |input: Span| length_count(le_u32, Player::parse_player(version))(input)
     }


### PR DESCRIPTION
vault does not build with `cargo build features --trace` as `parse_players`'s input param u16 does not implement nom_tracable::Tracable.

Implementing Tracable for u16 seems low value here as we already know we're in a DATADATA chunk.

Tested by building with `cargo build features --trace`.