### PR TITLE
Rename Ruby module to VaultCoh

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vault"
-version = "2.1.1"
+version = "3.0.0"
 edition = "2021"
 authors = ["Ryan Taylor <2320507+ryantaylor@users.noreply.github.com>"]
 
@@ -18,7 +18,7 @@ byteorder = "1"
 magnus = { version = "0.5", optional = true }
 nom = "7"
 nom_locate = "4"
-nom-tracable = "0.9.0"
+nom-tracable = "0.9"
 serde = { version = "1.0", features = ["derive"], optional = true }
 
 [features]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # vault
 
-[![Documentation](https://img.shields.io/badge/View-Documentation-blue.svg)](https://docs.rs/vault/2.1.1/vault/)
+[![Documentation](https://img.shields.io/badge/View-Documentation-blue.svg)](https://docs.rs/vault/3.0.0/vault/)
 
 `vault` is a Company of Heroes replay parsing library written in [Rust](https://www.rust-lang.org/). It has been completely rewritten for Company of Heroes 3 to provide a more intuitive interface while simplifying the code and leveraging [nom](https://github.com/rust-bakery/nom)'s parser combinators to enable clean, fast parsing of Company of Heroes 3 replay files.
 
@@ -16,7 +16,7 @@ If you are writing a Rust application, you can use `vault` from [crates.io](http
 
 ```toml
 [dependencies]
-vault = "2"
+vault = "3"
 ```
 
 `src/main.rs`:
@@ -37,7 +37,7 @@ fn main() {
 
 ```toml
 [dependencies]
-vault = { version = "2", features = ["magnus"] }
+vault = { version = "3", features = ["magnus"] }
 ```
 
 `src/lib.rs`:
@@ -47,7 +47,7 @@ use magnus::{class, define_module, exception, function, method, prelude::*, Erro
 
 #[magnus::init]
 fn init() -> Result<(), Error> {
-    let module = define_module("Vault")?;
+    let module = define_module("VaultCoh")?;
 
     let replay = module.define_class("Replay", class::object())?;
     replay.define_singleton_method("from_bytes", function!(from_bytes, 1))?;
@@ -68,11 +68,11 @@ fn from_bytes(input: Vec<u8>) -> Result<vault::Replay, Error> {
 require 'vault'
 
 bytes = File.open('/path/to/replay.rec').read.unpack('C*')
-replay = Vault::Replay.from_bytes(bytes)
+replay = VaultCoh::Replay.from_bytes(bytes)
 puts replay.version
 ```
 
-Note that all classes must be bound to the `Vault` namespace, with class names matching their Rust counterparts. For an example of this functionality in action, see [vault-rb](https://github.com/ryantaylor/vault-rb).
+Note that all classes must be bound to the `VaultCoh` namespace, with class names matching their Rust counterparts. For an example of this functionality in action, see [vault-rb](https://github.com/ryantaylor/vault-rb).
 
 ## Serde
 
@@ -82,7 +82,7 @@ Note that all classes must be bound to the `Vault` namespace, with class names m
 
 ```toml
 [dependencies]
-vault = { version = "2", features = ["serde"] }
+vault = { version = "3", features = ["serde"] }
 ```
 
 `src/main.rs`:

--- a/src/map.rs
+++ b/src/map.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[cfg_attr(feature = "magnus", magnus::wrap(class = "Vault::Map"))]
+#[cfg_attr(feature = "magnus", magnus::wrap(class = "VaultCoh::Map"))]
 pub struct Map {
     filename: String,
     localized_name_id: String,

--- a/src/message.rs
+++ b/src/message.rs
@@ -11,7 +11,7 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[cfg_attr(feature = "magnus", magnus::wrap(class = "Vault::Message"))]
+#[cfg_attr(feature = "magnus", magnus::wrap(class = "VaultCoh::Message"))]
 pub struct Message {
     tick: u32,
     message: String,

--- a/src/player.rs
+++ b/src/player.rs
@@ -14,7 +14,7 @@ use std::fmt::{Display, Formatter};
 
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[cfg_attr(feature = "magnus", magnus::wrap(class = "Vault::Player"))]
+#[cfg_attr(feature = "magnus", magnus::wrap(class = "VaultCoh::Player"))]
 pub struct Player {
     name: String,
     faction: Faction,
@@ -78,7 +78,7 @@ unsafe impl magnus::IntoValueFromNative for Player {}
 
 #[derive(Debug, Copy, Clone)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[cfg_attr(feature = "magnus", magnus::wrap(class = "Vault::Faction"))]
+#[cfg_attr(feature = "magnus", magnus::wrap(class = "VaultCoh::Faction"))]
 pub enum Faction {
     Americans,
     British,
@@ -115,7 +115,7 @@ impl TryFrom<&str> for Faction {
 
 #[derive(Debug, Copy, Clone)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[cfg_attr(feature = "magnus", magnus::wrap(class = "Vault::Team"))]
+#[cfg_attr(feature = "magnus", magnus::wrap(class = "VaultCoh::Team"))]
 pub enum Team {
     First = 0,
     Second = 1,

--- a/src/replay.rs
+++ b/src/replay.rs
@@ -15,7 +15,7 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[cfg_attr(feature = "magnus", magnus::wrap(class = "Vault::Replay"))]
+#[cfg_attr(feature = "magnus", magnus::wrap(class = "VaultCoh::Replay"))]
 pub struct Replay {
     version: u16,
     timestamp: String,


### PR DESCRIPTION
This is a breaking change, but is necessary to avoid naming collisions once the Ruby gem is released.