### PR TITLE
Fix 2.5.0 parsing errors

### DIFF
--- a/src/data/player.rs
+++ b/src/data/player.rs
@@ -59,8 +59,12 @@ impl Player {
 
             let (input, items) = Self::parse_items(input, &player)?;
 
-            // players in this chunk version or later have an extra 4 bytes between them for some reason
-            let (input, _) = cond(header.version >= 4595383, take(4u32))(input)?;
+            // Players in this chunk version or later carry a trailing count-prefixed list.
+            // It was empty in every replay up to game version 46673, which is why it used to
+            // read as four unexplained bytes between players; 2.5.0 (48652) began populating
+            // it — one 6-byte record (u32 pbgid, u16 slot) per entry — and reading only the
+            // count then derails the next player's parse.
+            let (input, _) = cond(header.version >= 4595383, Self::parse_slots)(input)?;
 
             Ok((
                 input,
@@ -118,5 +122,14 @@ impl Player {
                 battlegroup_items
             },
         ))(input)
+    }
+
+    /// The trailing per-player list `parse_player` describes. Each record is a pbgid and a
+    /// slot index; nothing in the public API exposes them yet, so they are read and dropped
+    /// to keep the player boundary correct.
+    #[tracable_parser]
+    fn parse_slots(input: Span) -> ParserResult<()> {
+        let (input, _) = length_count(le_u32, take(6u32))(input)?;
+        Ok((input, ()))
     }
 }

--- a/src/data/ticks/message_tick.rs
+++ b/src/data/ticks/message_tick.rs
@@ -1,7 +1,7 @@
 use crate::data::ticks::{Message, Tick};
 use crate::data::{ParserResult, Span};
-use nom::combinator::{cut, map, peek};
-use nom::multi::{length_data, length_value, many_m_n};
+use nom::combinator::{cut, map};
+use nom::multi::{length_data, length_value};
 use nom::number::complete::le_u32;
 use nom::sequence::tuple;
 
@@ -24,33 +24,35 @@ impl MessageTick {
         )(input)
     }
 
+    /// The payload opens with a kind, followed by the length of everything after it. Kind 1 is
+    /// chat and kind 0 carries nothing; both have been present since well before this parser.
+    /// Game version 48652 (patch 2.5.0) added kind 2, whose body is four bytes — shorter than
+    /// the chat header. Reading that leading value as a message count, as this parser used to,
+    /// then runs off the end of the payload and fails the entire replay, so anything that is
+    /// not chat is now skipped by its own declared length instead.
     fn parse_message(input: Span) -> ParserResult<Vec<Message>> {
-        let (_, num_messages) = peek(le_u32)(input)?;
+        let (input, kind) = le_u32(input)?;
 
-        if num_messages == 0 {
-            Self::parse_empty_message(input)
+        if kind == 1 {
+            Self::parse_chat_message(input)
         } else {
-            Self::parse_content_message(input, num_messages)
+            Self::parse_no_message(input)
         }
     }
 
-    fn parse_empty_message(input: Span) -> ParserResult<Vec<Message>> {
-        cut(map(tuple((le_u32, length_data(le_u32))), |(_, _)| {
-            Vec::new()
-        }))(input)
+    fn parse_no_message(input: Span) -> ParserResult<Vec<Message>> {
+        cut(map(length_data(le_u32), |_| Vec::new()))(input)
     }
 
-    fn parse_content_message(input: Span, num_messages: u32) -> ParserResult<Vec<Message>> {
-        cut(map(
-            tuple((
-                le_u32,
-                le_u32,
-                le_u32,
-                le_u32,
-                le_u32,
-                many_m_n(1, num_messages as usize, Message::parse_message),
-            )),
-            |(_, _, _, _, _, messages)| messages,
+    /// A slot, an eight-byte sender id, then the message. Parsed inside the body's own length
+    /// so that a body carrying more than we know how to read cannot desynchronise the ticks.
+    fn parse_chat_message(input: Span) -> ParserResult<Vec<Message>> {
+        cut(length_value(
+            le_u32,
+            map(
+                tuple((le_u32, le_u32, le_u32, Message::parse_message)),
+                |(_, _, _, message)| vec![message],
+            ),
         ))(input)
     }
 }


### PR DESCRIPTION
Patch 2.5.0 (game version **48652**) broke parsing in two independent places. Every replay recorded after the patch fails, at the same offset:

```
Parsing Failure: Error { input: LocatedSpan { offset: 5180, ... }, code: Eof }
```

### 1. The per-player trailing list

`parse_player` skips four bytes with the comment *"players in this chunk version or later have an extra 4 bytes between them for some reason"*. Those four bytes are a **count**, and it was zero in every replay up to build 46673 — which is why it read as padding. 2.5.0 populates it with one 6-byte record per entry (`u32` pbgid, `u16` slot), which lines up with the patch's lobby and battlegroup-selection rework.

Consuming only the count leaves the reader inside a record, so the next player's UTF-16 name length is read from the middle of a pbgid — a 16-million-character name, and `Eof`.

Reading it as a list needs **no version gate**: a count of zero consumes exactly the four bytes the old code did. I checked every player in 9 automatch replays on 46673 and the value is zero in all of them.

### 2. The message tick's leading `u32` is a kind, not a message count

`MessageTick::parse_message` peeks the first `u32` of the payload and treats it as a number of messages: `0` means empty, anything else means "read a 20-byte header, then that many messages". 2.5.0 introduced kind **2**, whose entire body is 4 bytes:

```
tick_type=1 payload_len=12
payload: 02 00 00 00 | 04 00 00 00 | 00 00 00 00
         kind          body length   body
```

The content path then reads 20 bytes out of a 12-byte payload and fails the replay. (Chat is kind `1`: `01 00 00 00 | 1e 00 00 00 | slot u32 | sender u64 | name | message`, and the second `u32` is the length of everything after it in every sample I have.)

Across a 2.4.2 corpus that leading value is only ever `1` (52 ticks) or `0` (3), so kind and count are indistinguishable from data alone — but two messages do not fit in four bytes. This PR dispatches on the kind, parses chat inside the body's own declared length, and skips an unrecognised kind by that same length, so a future kind cannot break parsing either.

### Verification

- `cargo test --features serde,raw`: **19 passed, 0 failed** (`regression` needs `replays/regression`, which isn't in the repo).
- Chat output over the 17 replays in `replays/` plus 9 automatch replays on 46673: **108 message lines, byte-identical before and after**.
- A separate consumer's 9 committed conformance snapshots (full normalized parse of each replay, serialized to JSON) **reproduce byte for byte**.
- 7 replays on 48652: total failure → every player and command parsed.

The tradeoff worth flagging: for kind 1 this reads exactly one message per tick rather than `many_m_n(1, count, ...)`. Every chat tick I can observe carries exactly one and its body length accounts for it precisely, but if you know of a tick that legitimately carries several, say so and I'll rework it to consume messages until the body is exhausted.

I did not add a test replay because the only 2.5.0 replays I have are my own and carry my Steam ID — happy to send one privately, or to add a fixture if you'd rather have one in the repo.
